### PR TITLE
Move cartodb vis controls to right

### DIFF
--- a/app/styles/layout/_map.scss
+++ b/app/styles/layout/_map.scss
@@ -24,12 +24,14 @@
   }
 }
 
-.view-map .leaflet-tiles-loader {
+.view-map .leaflet-tiles-loader,
+.view-map .cartodb-tiles-loader {
     float: right;
     margin-right: 20px;
 }
 
-.view-map .leaflet-zoom {
+.view-map .leaflet-zoom,
+.view-map .cartodb-zoom {
     float: right;
     margin-right: 20px;
 }


### PR DESCRIPTION
Trivial, merging. Reverts previous PR accidentally moving the controls back to the left.
